### PR TITLE
"As of" indicator on KeyedTicker

### DIFF
--- a/src/components/RankingDisplay/KeyableTicker/styles.scss
+++ b/src/components/RankingDisplay/KeyableTicker/styles.scss
@@ -4,12 +4,40 @@ $border-color: #222;
     height: 100%;
 }
 
+.tickerBox {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    width: 100vw;
+}
+
+.asOf {
+  background-color: #0c0e15;
+  color: white;
+  display: inline;
+  padding: .15em;
+  padding-left: 1.5em;
+  font-size: .65em;
+}
+
 .staticBottom {
+    display: flex;
+    flex-direction: column-reverse;
     position: fixed;
     bottom: 0;
+
+    .asOf {
+      -webkit-clip-path: polygon(1.2em 0, 0 100%, 100% 100%, 100% 0);
+      clip-path: polygon(1.2em 0, 0 100%, 100% 100%, 100% 0);
+    }
 }
 
 .staticTop {
     position: fixed;
     top: 0;
+
+    .asOf {
+      -webkit-clip-path: polygon(0 0, 1.2em 100%, 100% 100%, 100% 0);
+      clip-path: polygon(0 0, 1.2em 100%, 100% 100%, 100% 0);
+    }
 }


### PR DESCRIPTION
Optional display (default true) for the last time we were able to fetch data from FMS.

Note: This is not necessarily the last time that rankings were updated, but it should be close enough?

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3743825/229254626-80d4bf4c-1c0a-4eda-817a-503f627525f8.png">

